### PR TITLE
Fix ninja build on Windows

### DIFF
--- a/physx/source/foundation/include/PsAllocator.h
+++ b/physx/source/foundation/include/PsAllocator.h
@@ -37,7 +37,11 @@
 
 #if(PX_WINDOWS_FAMILY || PX_XBOXONE)
 	#include <exception>
-	#include <typeinfo.h>
+	#if(_MSC_VER >= 1923)
+		#include <typeinfo>
+	#else
+		#include <typeinfo.h>
+	#endif
 #endif
 #if(PX_APPLE_FAMILY)
 	#include <typeinfo>


### PR DESCRIPTION
The fix is adopted from upstream: 

https://github.com/NVIDIAGameWorks/PhysX/blob/a2c0428acab643e60618c681b501e86f7fd558cc/physx/source/foundation/include/PsAllocator.h#L40